### PR TITLE
Fix Edit & Populate modal to prevent closing when clicking outside

### DIFF
--- a/components/user-detail/user-detail-content.tsx
+++ b/components/user-detail/user-detail-content.tsx
@@ -969,7 +969,6 @@ export default function UserDetailContent({ userId, userEmail, targetSessionId, 
                                             {showEditPopulateModal && (
                                               <div
                                                 className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60 p-4"
-                                                onClick={() => setShowEditPopulateModal(false)}
                                               >
                                                 <div
                                                   className="relative w-[90vw] h-[90vh] bg-white rounded-2xl shadow-2xl flex flex-col overflow-hidden"


### PR DESCRIPTION
- Remove onClick handler from modal backdrop that was causing the modal to close when clicking outside the modal area
- Only the X button can now close the modal, improving user experience and preventing accidental closures
- Modal behavior is now more consistent with standard modal UX patterns

